### PR TITLE
Shorten context menu menuitems

### DIFF
--- a/background-scripts/qr-coder.js
+++ b/background-scripts/qr-coder.js
@@ -9,43 +9,43 @@ var QRCoderState = {
 crossBrowser.contextMenus.createQRCoder = function () {
   crossBrowser.contextMenus.create({
     id: "qr-coder-selection",
-    title: "Generate a QR Code for this selection",
+    title: "Generate QR Code for selection",
     contexts: ['selection']
   });
 
   crossBrowser.contextMenus.create({
     id: "qr-coder-link",
-    title: "Generate a QR Code for this link",
+    title: "Generate QR Code for link",
     contexts: ['link']
   });
 
   crossBrowser.contextMenus.create({
     id: "qr-coder-page",
-    title: "Generate a QR Code for this page",
+    title: "Generate QR Code for page",
     contexts: ['page']
   });
 
   crossBrowser.contextMenus.create({
     id: "qr-coder-image",
-    title: "Generate a QR Code for this image",
+    title: "Generate QR Code for image",
     contexts: ['image']
   });
 
   crossBrowser.contextMenus.create({
     id: "qr-coder-audio",
-    title: "Generate a QR Code for this sound",
+    title: "Generate QR Code for audio",
     contexts: ['audio']
   });
 
   crossBrowser.contextMenus.create({
     id: "qr-coder-video",
-    title: "Generate a QR Code for this video",
+    title: "Generate QR Code for video",
     contexts: ['video']
   });
 
   crossBrowser.contextMenus.create({
     id: "qr-coder-frame",
-    title: "Generate a QR Code for this frame",
+    title: "Generate QR Code for frame",
     contexts: ['frame']
   });
 };


### PR DESCRIPTION
Small change to shorten the menuitems.  Currently, the menuitems are quite long, which makes accessing context menu flyouts from Firefox or other extensions more difficult to access.  This pull request shortens the menuitems to minimize this effect.